### PR TITLE
:arrow_up: Bump tornado to 6.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pytest==7.1.2
 pytest-asyncio==0.19.0
-tornado==6.4.2
+tornado==6.5.0
 isodate==0.6.0
 python-redmine==2.2.1
 url-normalize==1.4.1


### PR DESCRIPTION
This fixes https://github.com/penguineer/RedmineActionablesCollector/security/dependabot/6