### PR TITLE
Add setuptools to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ tornado==6.5.0
 isodate==0.6.0
 python-redmine==2.2.1
 url-normalize==1.4.1
+
+# Needed for redmine lib, but no longer included by default in python:3.12
+setuptools==80.9.0


### PR DESCRIPTION
Python 3.12 no longer includes `distutils` by default. The `python-redmine` package (which uses `redminelib`) depends on it.

Install the `setuptools` package, which includes a vendored copy of `distutils`.

This fixes #15 .