### PR TITLE
Create a artifact attestation for docker images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,6 +10,10 @@ on:
     branches:
       - 'main'
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: mrtux/redmine-actionables-collector
+
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -21,7 +25,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: mrtux/redmine-actionables-collector
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             # 1.2.3
             type=semver,pattern={{version}}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,6 +17,10 @@ env:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -48,6 +52,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
+        id: push
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -55,3 +60,12 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        # The digest is only available after a push
+        if: steps.push.outputs.digest != ''
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -48,7 +48,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v7

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ HEALTHCHECK --interval=10s CMD curl --fail http://localhost:8080/v0/health || ex
 COPY src/OAS3.yml /
 
 COPY requirements.txt /
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt --root-user-action ignore
 
 COPY src/*.py /
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building and publishing the Docker image. The main improvements are the introduction of environment variables for the registry and image name, and the addition of a step to generate artifact attestations for enhanced supply chain security.

**Workflow configuration improvements:**

* Added `REGISTRY` and `IMAGE_NAME` environment variables at the workflow level to centralize and simplify image naming and registry references.
* Updated the Docker metadata action to use the new environment variables for image naming, improving maintainability and consistency.

**Supply chain security enhancements:**

* Added a new step to generate artifact attestations for the built Docker image using `actions/attest-build-provenance@v2`, which helps establish build provenance and increases supply chain security.