### PR TITLE
Add permissions to fix attestation push

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,9 +18,10 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
+      packages: write
       contents: read
       attestations: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This pull request makes a minor update to the permissions configuration in the `docker` job of the `.github/workflows/docker-image.yml` file. The change ensures that the workflow has the necessary permission to write to packages, while keeping other required permissions.

https://docs.github.com/en/actions/tutorials/publish-packages/publish-docker-images

* Updated the `permissions` block to include `packages: write` and reordered the entries for clarity in the `docker` job of `.github/workflows/docker-image.yml`.