### PR TITLE
Revert build attestation

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,11 +17,6 @@ env:
 jobs:
   docker:
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
-      attestations: write
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -61,13 +56,3 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Generate artifact attestation
-        # The digest is only available after a push
-        #if: steps.push.outputs.digest != ''
-        if: false
-        uses: actions/attest-build-provenance@v2
-        with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true


### PR DESCRIPTION
Build attestation with DockerHub needs to be figured out. So far it is not working properly. Remove the feature until it has been proven in a test environment.