### PR TITLE
Limit image build to linux/amd64 on PRs for faster CI

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,6 +13,7 @@ on:
 env:
   REGISTRY: docker.io
   IMAGE_NAME: mrtux/redmine-actionables-collector
+  TARGET_PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
 
 jobs:
   docker:
@@ -58,7 +59,7 @@ jobs:
         with:
           context: .
           # Use all platforms on push and tags, otherwise limit to linux/amd64 for faster CI
-          platforms: ${{ github.event_name != 'pull_request' && 'linux/amd64,linux/arm64,linux/arm/v7' || 'linux/amd64' }}
+          platforms: ${{ github.event_name != 'pull_request' && env.TARGET_PLATFORMS || 'linux/amd64' }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This pull request updates the Docker image build workflow to optimize build times during pull request CI runs. The main change is that multi-platform builds are now only performed on push and tag events, while pull requests are limited to building for `linux/amd64` to speed up CI.

Workflow optimization:

* [`.github/workflows/docker-image.yml`](diffhunk://#diff-dbade1e5797a7633e024a7685a43a7cbd96ae6fefc6314294807ae34cd83712cL60-R61): Modified the `platforms` option in the Docker build step to use all platforms (`linux/amd64,linux/arm64,linux/arm/v7`) only on push and tag events, and to use just `linux/amd64` for pull request events for faster CI runs.