### PR TITLE
Limit attestations to tagged releases

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -66,7 +66,8 @@ jobs:
 
       - name: Generate artifact attestation
         # The digest is only available after a push
-        if: steps.push.outputs.digest != ''
+        # Limit to tagged releases to avoid attesting every single merge to main
+        if: startsWith(github.ref, 'refs/tags/v') && steps.push.outputs.digest != ''
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}


### PR DESCRIPTION
This pull request updates the Docker image GitHub Actions workflow to improve efficiency by limiting when artifact attestations are generated. Now, attestations are only created for tagged releases, rather than for every merge to the main branch.

Workflow optimization:

* [`.github/workflows/docker-image.yml`](diffhunk://#diff-dbade1e5797a7633e024a7685a43a7cbd96ae6fefc6314294807ae34cd83712cL69-R70): Changed the condition for generating artifact attestations so that they are only created for tagged releases (refs starting with `refs/tags/v`) instead of every merge to main.