### PR TITLE
:arrow_up: Bump python-version in actions/setup-python to 3.13

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install python
       uses: actions/setup-python@v5
       with:
-          python-version: 3.9
+          python-version: 3.13
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
This pull request updates the Python version used in the GitHub Actions workflow for running tests. The workflow now uses Python 3.13 instead of 3.9, ensuring compatibility with the latest Python features and improvements.

- CI/CD configuration:
  * [`.github/workflows/pytest.yml`](diffhunk://#diff-2500680f4bc6c1b75c3d4b36372bf4d64c5f603b90bfd7a5186f66a20329d16aL19-R19): Updated the `python-version` in the setup step from 3.9 to 3.13.