### PR TITLE
CI: Cancel concurrent Docker builds

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,6 +15,10 @@ env:
   IMAGE_NAME: mrtux/redmine-actionables-collector
   TARGET_PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request introduces a workflow improvement to the `.github/workflows/docker-image.yml` file by adding concurrency controls. This ensures that only one instance of the workflow runs per branch or pull request, and any in-progress runs are cancelled when a new one is triggered.

Workflow enhancements:

* Added a `concurrency` group to the workflow configuration to prevent multiple simultaneous runs for the same branch or PR, improving CI efficiency and reducing resource usage.